### PR TITLE
Remove extra leading space on tag names in ComicInfo

### DIFF
--- a/src/comicinfoxml.rs
+++ b/src/comicinfoxml.rs
@@ -62,7 +62,7 @@ fn filter_and_combine_tags(tags: &[Tag], types: &[&str], display_type: bool) -> 
         (
             |tag|
             {
-                if display_type {format!("{}: {}", tag.r#type, tag.name)}
+                if display_type {format!("{}:{}", tag.r#type, tag.name)}
                 else {tag.name.clone()}
             }
         ) // change either to "{name}" or "{type}: {name}", because ComicInfo.xml + Komga don't have proper fields for all tag types


### PR DESCRIPTION
Komga might be stripping these out but on LANraragi this causes an issue.  Visually it removes it from the links the labels but it fails to find anything unless you go up and add that extra space into the search.  I've removed it and checked both Komga and LANraragi.  Komga still works normally and LANraragi now searches proper.