### PR TITLE
Using GTIN for archive id

### DIFF
--- a/src/comicinfoxml.rs
+++ b/src/comicinfoxml.rs
@@ -3,33 +3,29 @@
 use crate::api_response::*;
 use crate::hentai::*;
 
-
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, sqlx::FromRow)]
-pub struct ComicInfoXml
-{
-    pub Title: String, // pretty title
-    pub Year: i16, // upload year
-    pub Month: u8, // upload month
-    pub Day: u8, // upload day
-    pub Writer: Option<String>, // tag type: artist
+pub struct ComicInfoXml {
+    pub Title: String,              // pretty title
+    pub Year: i16,                  // upload year
+    pub Month: u8,                  // upload month
+    pub Day: u8,                    // upload day
+    pub Writer: Option<String>,     // tag type: artist
     pub Translator: Option<String>, // scanlator
-    pub Publisher: Option<String>, // tag type: group
-    pub Genre: Option<String>, // tag type: category
+    pub Publisher: Option<String>,  // tag type: group
+    pub Genre: Option<String>,      // tag type: category
     pub Tags: Option<String>, // tag types: character, language, parody, tag; language does not get own field "LanguageISO" because it only interprets 1 language as code properly, exhaustive language code list and only keeping 1 language if multiple present is janky
-    pub Web: String, // nhentai gallery
-
+    pub Web: String,          // nhentai gallery
+    pub GTIN: String,         // id
 }
 // ComicInfo.xml schema: https://anansi-project.github.io/docs/comicinfo/documentation
 // Komga interpretation: https://komga.org/docs/guides/scan-analysis-refresh/#import-metadata-for-cbrcbz-containing-a-comicinfoxml-file
 
-
-impl From<Hentai> for ComicInfoXml
-{
+impl From<Hentai> for ComicInfoXml {
     fn from(hentai: Hentai) -> Self // Hentai -> ComicInfo
     {
         return Self
         {
-            Title: format!("{} {}", hentai.id, hentai.title_pretty.unwrap_or_default()), // id and actual title, because can't search for field "Number" in komga
+            Title: format!("{}", hentai.title_pretty.unwrap_or_default()), // id and actual title, because can't search for field "Number" in komga
             Year: hentai.upload_date.format("%Y").to_string().parse::<i16>().unwrap_or_else(|_| panic!("Converting year \"{}\" to i16 failed even though it comes directly from chrono::DateTime.", hentai.upload_date.format("%Y"))),
             Month: hentai.upload_date.format("%m").to_string().parse::<u8>().unwrap_or_else(|_| panic!("Converting month \"{}\" to u8 failed even though it comes directly from chrono::DateTime.", hentai.upload_date.format("%m"))),
             Day: hentai.upload_date.format("%d").to_string().parse::<u8>().unwrap_or_else(|_| panic!("Converting day \"{}\" to u8 failed even though it comes directly from chrono::DateTime.", hentai.upload_date.format("%d"))),
@@ -39,10 +35,28 @@ impl From<Hentai> for ComicInfoXml
             Genre: filter_and_combine_tags(&hentai.tags, &["category"], false),
             Web: format!("https://nhentai.net/g/{id}/", id=hentai.id),
             Tags: filter_and_combine_tags(&hentai.tags, &["character", "language", "parody", "tag"], true),
-        }
+            GTIN: get_gtin(hentai.id),
+        };
     }
 }
 
+fn get_gtin(id: u32) -> String {
+    // create a 10 digit GTIN from the id
+    let id_str = id.to_string();
+    // add leading zeroes to make it 10 digits
+    let gtin = format!("{:0>9}", id_str);
+
+    // add check bit
+    let mut sum = 0;
+    for (i, c) in gtin.chars().enumerate() {
+        let digit = c.to_digit(10).unwrap();
+        let place = 10 - i;
+        sum += digit * place as u32;
+    }
+
+    let check_bit = (11 - (sum % 11)) % 11;
+    return format!("{}{}", gtin, check_bit);
+}
 
 /// # Summary
 /// Filters tags by type and combines the remaining into a single string. If no tags are found, returns None.
@@ -54,22 +68,34 @@ impl From<Hentai> for ComicInfoXml
 ///
 /// # Returns
 /// - filtered and combined tags or None
-fn filter_and_combine_tags(tags: &[Tag], types: &[&str], display_type: bool) -> Option<String>
-{
-    let mut tags_filtered: Vec<String> = tags.iter()
+fn filter_and_combine_tags(tags: &[Tag], types: &[&str], display_type: bool) -> Option<String> {
+    let mut tags_filtered: Vec<String> = tags
+        .iter()
         .filter(|tag| types.contains(&tag.r#type.as_str())) // only keep tags with type in types
-        .map
-        (
-            |tag|
-            {
-                if display_type {format!("{}: {}", tag.r#type, tag.name)}
-                else {tag.name.clone()}
+        .map(|tag| {
+            if display_type {
+                format!("{}: {}", tag.r#type, tag.name)
+            } else {
+                tag.name.clone()
             }
-        ) // change either to "{name}" or "{type}: {name}", because ComicInfo.xml + Komga don't have proper fields for all tag types
+        }) // change either to "{name}" or "{type}: {name}", because ComicInfo.xml + Komga don't have proper fields for all tag types
         .collect();
     tags_filtered.sort(); // sort alphabetically
-    let tags_filtered_combined: Option<String> = Some(tags_filtered.join(",")) // join at ","
-        .and_then(|s| if s.is_empty() {None} else {Some(s)}); // convert Some("") to None, otherwise forward unchanged
+    let tags_filtered_combined: Option<String> =
+        Some(tags_filtered.join(",")) // join at ","
+            .and_then(|s| if s.is_empty() { None } else { Some(s) }); // convert Some("") to None, otherwise forward unchanged
 
     return tags_filtered_combined;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotate_1() {
+        assert_eq!(get_gtin(0), "0000000000");
+        assert_eq!(get_gtin(42), "0000000426");
+        assert_eq!(get_gtin(1337), "0000013374");
+    }
 }


### PR DESCRIPTION
This is a hacky-but-it-works fix for https://github.com/9-FS/nhentai_archivist/issues/29. Komga parses the GTIN as the ISBN number [here](https://github.com/gotson/komga/blob/25a1cfa8660c57335313c244e41c248371ffd9d6/komga/src/main/kotlin/org/gotson/komga/infrastructure/metadata/comicrack/ComicInfoProvider.kt#L107) then makes the ISBN number searchable [here](https://github.com/gotson/komga/blob/25a1cfa8660c57335313c244e41c248371ffd9d6/komga/src/main/kotlin/org/gotson/komga/infrastructure/search/LuceneEntity.kt#L29). When parsing the GTIN, Komga does try to validate the number so I had to force it to be 10 digits and make the last digit (the checksum) valid.