### PR TITLE
Fixed the invalid docker compose environment syntax in readme.md 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,13 +92,13 @@ I'm happy about anyone who finds my software useful and feedback is also always 
 
     ```YAML
     environment:
-        - NHENTAI_TAGS: '[language:"english"]' # all english hentai
-        - NHENTAI_TAGS: '[tag:"big breasts"]' # all hentai with the tag "big breasts"
-        - NHENTAI_TAGS: '[parody:"kono subarashii sekai ni syukufuku o"]' # all hentai from the anime "Kono Subarashii Sekai ni Syukufuku o"
-        - NHENTAI_TAGS: '[artist:"shindol"]' # all hentai by Shindol
-        - NHENTAI_TAGS: '[character:"frieren"]' # all hentai with character "Frieren"
-        - NHENTAI_TAGS: '[tag:"ffm threesome", tag:"sister", -tag:"full censorship", -tag:"mind control"]' # all hentai with the tags "ffm threesome" and "sister" but without the tags "full censorship" and "mind control"
-    ```
+      NHENTAI_TAGS: '[language:"english"]' # all english hentai
+      NHENTAI_TAGS: '[tag:"big breasts"]' # all hentai with the tag "big breasts"
+      NHENTAI_TAGS: '[parody:"kono subarashii sekai ni syukufuku o"]' # all hentai from the anime "Kono Subarashii Sekai ni Syukufuku o"
+      NHENTAI_TAGS: '[artist:"shindol"]' # all hentai by Shindol
+      NHENTAI_TAGS: '[character:"frieren"]' # all hentai with character "Frieren"
+      NHENTAI_TAGS: '[tag:"ffm threesome", tag:"sister", -tag:"full censorship", -tag:"mind control"]' # all hentai with the tags "ffm threesome" and "sister" but without the tags "full censorship" and "mind control"
+   ```
 
     Pay attention to copy the format exactly as shown in the examples. That includes the usage of single quotation marks outside and double quotation marks inside. If the format is not being copied exactly, at least searching by tags that contain a space leads to erroneous API responses. More information can be found [here](https://nhentai.net/info/).
 

--- a/readme.md
+++ b/readme.md
@@ -92,13 +92,13 @@ I'm happy about anyone who finds my software useful and feedback is also always 
 
     ```YAML
     environment:
-      NHENTAI_TAGS: '[language:"english"]' # all english hentai
-      NHENTAI_TAGS: '[tag:"big breasts"]' # all hentai with the tag "big breasts"
-      NHENTAI_TAGS: '[parody:"kono subarashii sekai ni syukufuku o"]' # all hentai from the anime "Kono Subarashii Sekai ni Syukufuku o"
-      NHENTAI_TAGS: '[artist:"shindol"]' # all hentai by Shindol
-      NHENTAI_TAGS: '[character:"frieren"]' # all hentai with character "Frieren"
-      NHENTAI_TAGS: '[tag:"ffm threesome", tag:"sister", -tag:"full censorship", -tag:"mind control"]' # all hentai with the tags "ffm threesome" and "sister" but without the tags "full censorship" and "mind control"
-   ```
+        NHENTAI_TAGS: '[language:"english"]' # all english hentai
+        NHENTAI_TAGS: '[tag:"big breasts"]' # all hentai with the tag "big breasts"
+        NHENTAI_TAGS: '[parody:"kono subarashii sekai ni syukufuku o"]' # all hentai from the anime "Kono Subarashii Sekai ni Syukufuku o"
+        NHENTAI_TAGS: '[artist:"shindol"]' # all hentai by Shindol
+        NHENTAI_TAGS: '[character:"frieren"]' # all hentai with character "Frieren"
+        NHENTAI_TAGS: '[tag:"ffm threesome", tag:"sister", -tag:"full censorship", -tag:"mind control"]' # all hentai with the tags "ffm threesome" and "sister" but without the tags "full censorship" and "mind control"
+    ```
 
     Pay attention to copy the format exactly as shown in the examples. That includes the usage of single quotation marks outside and double quotation marks inside. If the format is not being copied exactly, at least searching by tags that contain a space leads to erroneous API responses. More information can be found [here](https://nhentai.net/info/).
 


### PR DESCRIPTION
Current version of the example has a mix of invalid syntax for docker (string list and key-value mapping) and will cause an error when trying to build the docker image.
I've switched it to use key-value mapping. This allows users to copy paste the example directly into their docker compose and will build correctly. 
   