### PR TITLE
Updated and simplified docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,10 @@
 services:
-    nhentai_archivist:
-        container_name: "nhentai_archivist"
-        image: "ghcr.io/9-fs/nhentai_archivist:3.8.3"
-        environment:
-            HOST_OS: "Unraid"
-            TZ: "UTC"
-        volumes:
-            - "/mnt/user/appdata/nhentai_archivist/config/:/app/config/:rw"
-            - "/mnt/user/appdata/nhentai_archivist/db/:/app/db/:rw"
-            - "/mnt/user/appdata/nhentai_archivist/log/:/app/log/:rw"
-            - "/mnt/user/nextcloud/media/hentai/:/app/hentai/:rw"
-        user: "99:100"
-        network_mode: "bridge"
-        deploy:
-            resources:
-                limits:
-                    memory: "1G"
+  nhentai_archivist:
+    image: ghcr.io/9-fs/nhentai_archivist_archivist:3.8.3
+    container_name: nhentai_archivist
+    volumes:
+      - /path/to/nhentai_archivist/config/:/app/config/
+      - /path/to/nhentai_archivist/db/:/app/db/
+      - /path/to/nhentai_archivist/log/:/app/log/
+      - /path/to/nhentai_archivist/hentai/:/app/hentai/
+    restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,12 @@
+name: "nhentai_archivist"
+
 services:
-  nhentai_archivist:
-    image: ghcr.io/9-fs/nhentai_archivist_archivist:3.8.3
-    container_name: nhentai_archivist
-    volumes:
-      - /path/to/nhentai_archivist/config/:/app/config/
-      - /path/to/nhentai_archivist/db/:/app/db/
-      - /path/to/nhentai_archivist/log/:/app/log/
-      - /path/to/nhentai_archivist/hentai/:/app/hentai/
-    restart: unless-stopped
+    nhentai_archivist:
+        container_name: "nhentai_archivist"
+        image: "ghcr.io/9-fs/nhentai_archivist:latest"
+        mem_limit: "1G"
+        volumes:
+            - "/path/to/nhentai_archivist/config/:/app/config/"
+            - "/path/to/nhentai_archivist/db/:/app/db/"
+            - "/path/to/nhentai_archivist/log/:/app/log/"
+            - "/path/to/hentai_library/:/app/hentai/"


### PR DESCRIPTION
There were several build issues with the existing `docker-compose.yaml`, perhaps due to a tool like `Composerize` being used. I made the following corrections:

- Removed unnecessary/unusable fields:
`HOST_OS:` -- not needed by the container.
`TZ:` -- does not work with distroless images (no shell or timezone files).
`user: "99:100"` -- silently fails with `gcr.io/distroless/cc`, which lacks `/etc/passwd` or `shell` support.

- Cleaned up volume declarations:
Removed `:rw` from volumes -- Docker uses `read/write` mode by default.

- Removed network setting:
`network_mode: "bridge"` -- Docker Compose uses a bridge network by default unless manually overridden.

- Removed deploy setting:
`deploy.resources.limits` -- This only works in Docker Swarm mode and has no effect in standard Compose.
Whilst I didn't find a need to limit resources, you can do so via the optional setting `mem_limit: 1g` 

- Added the option `restart: unless-stopped` -- This allows the container to start up again if due to failure or a crash unless it is manually stopped by the user. 

If my schedule allows, I would in a future commit like to propose a switch from the distroless image to alpine and make a few tweaks to the Dockerfile to better support `PUID/PGID` or at least support the `user:` setting. This would allow a little more flexibility as the container currently runs and creates folders/doujins with `root`.

As your project is written in rust, would you have difficulties finding the appropriate rust libraries in alpine?

On the other hand, I love how minimal the new docker-compose is and I don't see a need to frequently `exec` into container. Currently docker users will have to use `sudo` and `sudo chown` on their downloaded files or a be `root` to move/delete files afterwards. Switching to a more flexible user setup could alleviate this issue.